### PR TITLE
set up the cloud infrastructure for dashboard hosting and complete without docker image

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -2,7 +2,12 @@
 This folder contains a Streamlit dashboard that loads data from the RDS using psycopg2.
 To run locally: `streamlit run dashboard.py`.
 
-# Requirements
+Also contains sub-folders:
+
+* terraform/
+
+# Dashboard - running locally
+## Requirements
 
 To install requirements run:
 `pip install -r requirements.txt`
@@ -20,3 +25,86 @@ DB_PORT=
 
 Dashboard Wireframe:
 ![Dashboard Wireframe](../assets/dashboard_wireframe.png)
+
+
+
+
+# Terraform
+
+terraform/ - contains code for storage infrastructure
+
+* main.tf
+
+    * Creates an ECR repository for the dashboard docker image
+    * Creates a security group for the dashboard
+    * Specifies ingress-egress rules for the security group
+    * Creates a CloudWatch log group for the ECS service
+    * Creates a ECS task definition
+    * Triggers an ECS service based on the task definition
+    * Returns the ECR image uri's in the terminal once step 1 from below has finished running.
+
+* variables.tf 
+
+    * allows for environmental variables to be passed into the main file.
+
+* outputs.tf 
+
+    * allows for the image uri's to be returned to the terminal when performing step 1 above
+
+Please setup a third file, `terraform.tfvars`, that specifies environmental variables and follows this format:
+
+```
+DB_USERNAME=<your_database_username>
+DB_PASSWORD=<your_database_password>
+DB_PORT=5432
+DB_NAME=<your_database_name>
+DB_HOST=<your_database_address>
+```
+
+This configuration assumes that AWS CLI has been set up and so AWS keys are not required within the `terraform.tfvars`. If you haven't set up the AWS CLI, you can follow up to step 3 from this [article](https://medium.com/@simonazhangzy/installing-and-configuring-the-aws-cli-7d33796e4a7c) to help you.
+
+
+## Get started
+
+The Terraform files can be run using the following steps for the first time:
+
+1. Run `terraform init`
+
+2. Once successful, run the commands below to create the ECR repository for the dashboard image:  
+    * `terraform apply -target=aws_ecr_repository.c16-book-project-dashboard-ecr`
+
+3. Copy the image uri outputted in the console from step 2 and paste the value into the corresponding variable in the `variables.tf` file
+
+4. Carry out the steps below to add a Docker image to the new ECR repository that has been created under the heading ECR Image.
+
+5. Run `terraform apply` once the previous step is complete to apply the rest of script.
+
+Once the ECR repository has been set up with a Docker image, only step 5 is required to set up the infrastructure from now on.
+
+
+# ECR Image
+
+### **≤CONTAINS ALL THE STEPS REQUIRED TO SET UP THE DOCKER IMAGE FOR THE DASHBOARD DEPENDING ON FILE FORMAT TO BE CHANGED V≥**
+
+#### ...
+add_ecr/ - Contains code for setting up the lambda Docker image
+
+This is an example folder for deploying a lambda script to AWS ECR. Two folders should be created that follow the same structure for both ECR repositories, containing:
+
+* `Dockerfile` - which includes the commands required to convert the lambda function script into a Docker image
+
+* `placeholder_image_for_ecr.py` - which is the lambda script to be converted into a Docker image.
+
+
+## Get started
+
+To set up the ECR repository with the lambda Docker image, carry out the following steps after carrying out steps 1 and 2 from the terraform section:
+
+1. Replace the `placeholder_image_for_ecr.py` placeholder script with your lambda script
+
+2. Replace `placeholder_image_for_ecr` in the `Dockerfile` on line 5 and 9 with the name of your script.
+
+3. Follow the steps on [here](https://docs.aws.amazon.com/lambda/latest/dg/python-image.html#python-image-instructions) to dockerise the python script.
+
+4. Follow the push commands on the AWS console for the relevant ECR repository
+#### ...

--- a/dashboard/terraform/main.tf
+++ b/dashboard/terraform/main.tf
@@ -1,0 +1,185 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.32.0"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+
+
+# ECRs
+resource "aws_ecr_repository" "c16-book-project-dashboard-ecr" {
+  name                 = "${var.ecs_name}-ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# NETWORKING
+data "aws_vpc" "c16-vpc" {
+    id = var.c16-VPC
+}
+
+data "aws_subnets" "selected" {
+  filter {
+    name   = "tag:Name"
+    values = [ "c16-public-subnet-2", "c16-public-subnet-1", "c16-public-subnet-3" ]
+  }
+}
+
+resource "aws_security_group" "c16-book-project-dashboard-sg" {
+    name = "${var.ecs_name}-sg"
+    vpc_id = var.c16-VPC
+}
+
+resource "aws_vpc_security_group_ingress_rule" "read_from_database_ipv4" {
+    security_group_id = aws_security_group.c16-book-project-dashboard-sg.id
+    cidr_ipv4 = "0.0.0.0/0"
+    from_port = tonumber(var.DB_PORT)
+    to_port = tonumber(var.DB_PORT)
+    ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "read_from_database_ipv6" {
+    security_group_id = aws_security_group.c16-book-project-dashboard-sg.id
+    cidr_ipv6 = "::/0"
+    from_port = tonumber(var.DB_PORT)
+    to_port = tonumber(var.DB_PORT)
+    ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_access_to_dashboard_ipv4" {
+    security_group_id = aws_security_group.c16-book-project-dashboard-sg.id
+    cidr_ipv4 = "0.0.0.0/0"
+    from_port = 8501
+    to_port = 8501
+    ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_access_to_dashboard_ipv6" {
+  security_group_id = aws_security_group.c16-book-project-dashboard-sg.id
+  cidr_ipv6 = "::/0"
+  from_port = 8501
+  to_port = 8501
+  ip_protocol = "tcp" 
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_access_for_aws_ecs_ipv6" {
+  security_group_id = aws_security_group.c16-book-project-dashboard-sg.id
+  cidr_ipv6 = "::/0"
+  from_port = 443
+  to_port = 443
+  ip_protocol = "tcp" 
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_access_for_aws_ecs_ipv4" {
+  security_group_id = aws_security_group.c16-book-project-dashboard-sg.id
+  cidr_ipv4 = "0.0.0.0/0"
+  from_port = 443
+  to_port = 443
+  ip_protocol = "tcp" 
+}
+
+# LOGGING
+resource "aws_cloudwatch_log_group" "c16-book-project-dashboard-lg" {
+  name = "/ecs/${var.ecs_name}"
+  retention_in_days = 0
+}
+
+resource "aws_cloudwatch_log_stream" "c16-book-project-dashboard-ls" {
+  name           = "ecs/${var.ecs_name}/"
+  log_group_name = aws_cloudwatch_log_group.c16-book-project-dashboard-lg.name
+}
+
+
+# ECS TASK DEFINITION
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+
+resource "aws_ecs_task_definition" "c16-book-project-dashboard-td" {
+    family = aws_ecr_repository.c16-book-project-dashboard-ecr.name
+    requires_compatibilities = ["FARGATE"]
+    network_mode             = "awsvpc"
+    cpu = 512
+    memory = 1024
+    execution_role_arn = data.aws_iam_role.ecs_task_execution_role.arn
+    container_definitions = jsonencode([{
+        name      = var.ecs_name
+        image     = var.image_uri_for_dashboard
+        essential = true
+        command = ["python3", "dashboard.py"]
+        environment = [
+            {
+                name = "DB_HOST"
+                value = var.DB_HOST
+            },
+            {
+                name = "DB_NAME"
+                value = var.DB_NAME
+            },
+            {
+                name = "DB_USERNAME"
+                value = var.DB_USERNAME
+            },
+            {
+                name = "DB_PASSWORD"
+                value = var.DB_PASSWORD
+            },
+            {
+                name = "DB_PORT"
+                value = var.DB_PORT
+            }]
+        portMappings = [
+            {
+            containerPort = tonumber(var.DB_PORT)
+            hostPort      = tonumber(var.DB_PORT)
+            }
+        ]
+        logConfiguration = {
+            logDriver = "awslogs",
+            options = {
+                awslogs-group = "${aws_cloudwatch_log_group.c16-book-project-dashboard-lg.name}",
+                awslogs-region = "eu-west-2",
+                awslogs-stream-prefix = "ecs"
+                }
+            }
+        }
+    ])
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture = "X86_64"
+  }
+}
+
+data "aws_ecs_cluster" "c16-ecs-cluster" {
+  cluster_name = "c16-ecs-cluster"
+}
+
+
+
+# ECS SERVICE
+resource "aws_ecs_service" "c16-book-project-dashboard" {
+  name            = "${var.ecs_name}-ecs-service"
+  cluster         = data.aws_ecs_cluster.c16-ecs-cluster.id
+  task_definition = aws_ecs_task_definition.c16-book-project-dashboard-td.arn
+  desired_count   = 1
+  launch_type = "FARGATE"
+
+  network_configuration {
+    assign_public_ip = true
+    security_groups  = [aws_security_group.c16-book-project-dashboard-sg.id]
+    subnets          = data.aws_subnets.selected.ids
+  }
+}

--- a/dashboard/terraform/outputs.tf
+++ b/dashboard/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "image_uri_for_dashboard" {
+    value = aws_ecr_repository.c16-book-project-dashboard-ecr.repository_url
+}

--- a/dashboard/terraform/variables.tf
+++ b/dashboard/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "DB_USERNAME" {
+  type=string
+}
+
+variable "DB_PASSWORD" {
+  type=string
+}
+
+variable "DB_NAME" {
+  type=string
+}
+
+variable "DB_PORT" {
+  type=string
+}
+
+variable "DB_HOST" {
+  type=string
+}
+
+variable "c16-VPC" {
+  type=string
+  default = "vpc-0f7ba8057a52dd82d"
+}
+
+variable "ecs_name" {
+    type=string
+    default = "c16-book-project-dashboard"
+}
+
+variable "image_uri_for_dashboard" {
+    type=string
+    default =  "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c16-book-project-dashboard-ecr"
+}


### PR DESCRIPTION
Created an ECR and ECS task definition for the dashboard and triggered an ECS service to host the dashboard. All that is left is to convert the dashboard into a Docker image to upload that into the created ECR and update the README.md with the process of Dockerising the dashboard.
