### PR TITLE
bug fixed so automated pylinter fails GH actions if the pylint score for a file is under 8

### DIFF
--- a/scripts/pylint_directories.sh
+++ b/scripts/pylint_directories.sh
@@ -1,3 +1,4 @@
+"" > pylint_testing_result.txt
 git ls-tree -t HEAD:./ | awk '{if ($2 == "tree") print $4;}' | grep -e '^[a-zA-Z]' > all_dir.txt
 
 echo pylinting all python files in every dir
@@ -7,10 +8,20 @@ num_of_dir=$(wc -l all_dir.txt | awk ' { print $1 } ')
 for i in $(seq 1 ${num_of_dir});
 do
     dir_in_repo=$(sed "${i}q;d" all_dir.txt)
-    pylint --recursive=y ${dir_in_repo} --fail-under 8
+    pylint --fail-under 8.0 --recursive=y ${dir_in_repo} >> pylint_testing_result.txt
 done
 
-echo pylinting rest of python files in main repo
-pylint '*.py' --fail-under 8
+cat pylint_testing_result.txt
 
 echo "All files pylinted"
+
+test_result=$(grep -e '[a-zA-Z\s]*[0-7]\.[0-9][0-9]\/10' pylint_testing_result.txt)
+if [[ -n "$test_result" ]]; then
+    echo "Pylint scores below 8!"
+    exit 1
+else
+    echo "All scores are 8 and above!"
+fi
+
+rm pylint_testing_result.txt
+rm all_dir.txt

--- a/scripts/pylint_directories.sh
+++ b/scripts/pylint_directories.sh
@@ -8,14 +8,14 @@ num_of_dir=$(wc -l all_dir.txt | awk ' { print $1 } ')
 for i in $(seq 1 ${num_of_dir});
 do
     dir_in_repo=$(sed "${i}q;d" all_dir.txt)
-    pylint --fail-under 8.0 --recursive=y ${dir_in_repo} >> pylint_testing_result.txt
+    pylint --recursive=y ${dir_in_repo} >> pylint_testing_result.txt
 done
 
 cat pylint_testing_result.txt
 
 echo "All files pylinted"
 
-test_result=$(grep -e '[a-zA-Z\s]*[0-7]\.[0-9][0-9]\/10' pylint_testing_result.txt)
+test_result=$(grep -e '[a-zA-Z\s]{1}[0-7]\.[0-9][0-9]\/10' pylint_testing_result.txt)
 if [[ -n "$test_result" ]]; then
     echo "Pylint scores below 8!"
     exit 1


### PR DESCRIPTION
In the `pylint_directories.sh` bash file, I've used the grep command to pull all the 'Your code is rated at [3.00/10.0]' lines from the pylint output filtered by any values of 7.99 and below. This is then used within the if else block to help identify if GH actions should fail or pass based on whether any output that fits the pattern exists.