### PR TITLE
fixed test_extract testing not working outside of its directory

### DIFF
--- a/pipeline/test_extract.py
+++ b/pipeline/test_extract.py
@@ -1,14 +1,20 @@
 # pylint: skip-file
 import pytest
+from os import path
 from bs4 import BeautifulSoup
 from unittest.mock import patch
 import extract
 
 
+def get_file_path(filename):
+    return path.join(path.dirname(__file__), filename)
+
+
 @pytest.fixture
 def mock_book_page_soup():
     '''Simulates the soup for the HTML for a goodreads book page used for testing.'''
-    with open('./test_book_page.html', 'r', encoding="utf-8") as f:
+    filepath = get_file_path('test_book_page.html')
+    with open(filepath, 'r', encoding="utf-8") as f:
         html_content = f.read()
     return BeautifulSoup(html_content, "lxml")
 
@@ -16,7 +22,17 @@ def mock_book_page_soup():
 @pytest.fixture
 def mock_book_list_page_soup():
     '''Simulates the soup for the HTML for a goodreads book list page used for testing.'''
-    with open('./test_book_list.html', 'r', encoding="utf-8") as f:
+    filepath = get_file_path('test_book_list.html')
+    with open(filepath, 'r', encoding="utf-8") as f:
+        html_content = f.read()
+    return BeautifulSoup(html_content, "lxml")
+
+
+@pytest.fixture
+def mock_author_page_soup():
+    '''Simulates the soup for the HTML for a goodreads author page used for testing.'''
+    filepath = get_file_path('test_author_page.html')
+    with open(filepath, 'r', encoding="utf-8") as f:
         html_content = f.read()
     return BeautifulSoup(html_content, "lxml")
 
@@ -31,14 +47,6 @@ def mock_book_list_page_containers_sliced(mock_book_list_page_soup):
 @pytest.fixture
 def mock_book_list_page_container_soup(mock_book_list_page_containers_sliced):
     return mock_book_list_page_containers_sliced[0]
-
-
-@pytest.fixture
-def mock_author_page_soup():
-    '''Simulates the soup for the HTML for a goodreads author page used for testing.'''
-    with open('./test_author_page.html', 'r', encoding="utf-8") as f:
-        html_content = f.read()
-    return BeautifulSoup(html_content, "lxml")
 
 
 def test_get_authors_books_url(mock_author_page_soup):

--- a/pipeline/test_extract.py
+++ b/pipeline/test_extract.py
@@ -6,12 +6,12 @@ from unittest.mock import patch
 import extract
 
 
-def get_file_path(filename):
+def get_file_path(filename: str) -> str:
     return path.join(path.dirname(__file__), filename)
 
 
 @pytest.fixture
-def mock_book_page_soup():
+def mock_book_page_soup() -> BeautifulSoup:
     '''Simulates the soup for the HTML for a goodreads book page used for testing.'''
     filepath = get_file_path('test_book_page.html')
     with open(filepath, 'r', encoding="utf-8") as f:
@@ -20,7 +20,7 @@ def mock_book_page_soup():
 
 
 @pytest.fixture
-def mock_book_list_page_soup():
+def mock_book_list_page_soup() -> BeautifulSoup:
     '''Simulates the soup for the HTML for a goodreads book list page used for testing.'''
     filepath = get_file_path('test_book_list.html')
     with open(filepath, 'r', encoding="utf-8") as f:
@@ -29,7 +29,7 @@ def mock_book_list_page_soup():
 
 
 @pytest.fixture
-def mock_author_page_soup():
+def mock_author_page_soup() -> BeautifulSoup:
     '''Simulates the soup for the HTML for a goodreads author page used for testing.'''
     filepath = get_file_path('test_author_page.html')
     with open(filepath, 'r', encoding="utf-8") as f:
@@ -38,14 +38,14 @@ def mock_author_page_soup():
 
 
 @pytest.fixture
-def mock_book_list_page_containers_sliced(mock_book_list_page_soup):
+def mock_book_list_page_containers_sliced(mock_book_list_page_soup) -> list[BeautifulSoup]:
     '''Gets a list of the html for the top 2 book containers in the 
     goodreads author's book list page.'''
     return mock_book_list_page_soup.find_all("tr")[:1]
 
 
 @pytest.fixture
-def mock_book_list_page_container_soup(mock_book_list_page_containers_sliced):
+def mock_book_list_page_container_soup(mock_book_list_page_containers_sliced) -> BeautifulSoup:
     return mock_book_list_page_containers_sliced[0]
 
 


### PR DESCRIPTION
# Overview:

### Bug:

pytest would not be able to call the test_*.html files inside of the pipeline folder when attemting to test inside of that folder from outside that folder


### Fix:

The extract test file now specifies the generates the exact path of the mock pages that are in html files and passes these when mocking, allowing the tests to be run from any directory.  